### PR TITLE
chore: correct spelling of Portimaõ

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -8,9 +8,9 @@ const Footer = () => {
           <h1 footer-title>AURORA</h1>
           <p className="info">mcaaurora2020@gmail.com</p>
           <p className="info">+351 965 118 884</p>
-          <p className="info">Portugal, Potrimāo</p>
+          <p className="info">Portimāo, Portugal</p>
           <p className="info">+38 093 072 61 57 </p>
-          <p className="info">Ukraine, Odesa</p>
+          <p className="info">Odesa, Ukraine</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This is similar to #3 (I created this work before seeing that work). However, this PR also introduces a reordering of the country and city in the address. Commonly, cities are placed before countries when addressed. So, we propose this reordering, here. If this work is accepted then #3 should be closed. It's also worth noting that #3 also includes dictionary files for VSCode which are unlikely to benefit other developers and aren't relevant to this repository's work and, so, should probably not be included in the codebase.