### PR TITLE
fix: ensure navbar is initially inactive on mobile

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -6,14 +6,14 @@ import logo from "../img/logo_w1.jpg"
 
 
 class Navbar extends Component {
-  state = { clicked: "false" };
+  state = { clicked: false };
   handleClick = () => {
     this.setState({ clicked: !this.state.clicked });
   };
   render() {
     return (
       <nav className="NavbarItems">
-        
+
         <Link to="/" className="navbar-logo">
           <img src={logo} alt="AURORA Logo" />
         </Link>


### PR DESCRIPTION
Prior to this work, the value of `state` within the `NavBar` component was `"false"`, a string. The value of `"false"` is truthy (one can confirm this by running `!!"false"` in a JavaScript interpreter. The truthy value resulted in the `active` CSS styles. So, the hamburger menu was expanded, by default. This negatively impacted the mobile experience. This PR introduces a change t the `state` value. Importantly, it changes the initial value to `false` instead of `"false"` so that the hamburger menu behaves as expected.